### PR TITLE
Feature/81/terraform

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,20 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,45 @@
+name: "Terraform Apply"
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  TF_CLOUD_ORGANIZATION: "Grupo-G03-4SOAT-FIAP"
+  TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
+  TF_WORKSPACE: "rms-db"
+  CONFIG_DIRECTORY: "./"
+
+jobs:
+  terraform:
+    if: github.repository != 'hashicorp-education/learn-terraform-github-actions'
+    name: "Terraform Apply"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Upload Configuration
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.0
+        id: apply-upload
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          directory: ${{ env.CONFIG_DIRECTORY }}
+
+      - name: Create Apply Run
+        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.0
+        id: apply-run
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          configuration_version: ${{ steps.apply-upload.outputs.configuration_version_id }}
+
+      - name: Apply
+        uses: hashicorp/tfc-workflows-github/actions/apply-run@v1.0.0
+        if: fromJSON(steps.apply-run.outputs.payload).data.attributes.actions.IsConfirmable
+        id: apply
+        with:
+          run: ${{ steps.apply-run.outputs.run_id }}
+          comment: "Apply Run from GitHub Actions CI ${{ github.sha }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,80 @@
+name: "Terraform Plan"
+
+on:
+  pull_request:
+
+env:
+  TF_CLOUD_ORGANIZATION: "Grupo-G03-4SOAT-FIAP"
+  TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
+  TF_WORKSPACE: "rms-db"
+  CONFIG_DIRECTORY: "./"
+
+jobs:
+  terraform:
+    if: github.repository != 'hashicorp-education/learn-terraform-github-actions'
+    name: "Terraform Plan"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Upload Configuration
+        uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.0
+        id: plan-upload
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          directory: ${{ env.CONFIG_DIRECTORY }}
+          speculative: true
+
+      - name: Create Plan Run
+        uses: hashicorp/tfc-workflows-github/actions/create-run@v1.0.0
+        id: plan-run
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          configuration_version: ${{ steps.plan-upload.outputs.configuration_version_id }}
+          plan_only: true
+
+      - name: Get Plan Output
+        uses: hashicorp/tfc-workflows-github/actions/plan-output@v1.0.0
+        id: plan-output
+        with:
+          plan: ${{ fromJSON(steps.plan-run.outputs.payload).data.relationships.plan.data.id }}
+
+      - name: Update PR
+        uses: actions/github-script@v6
+        id: plan-comment
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Cloud Plan Output')
+            });
+            const output = `#### Terraform Cloud Plan Output
+               \`\`\`
+               Plan: ${{ steps.plan-output.outputs.add }} to add, ${{ steps.plan-output.outputs.change }} to change, ${{ steps.plan-output.outputs.destroy }} to destroy.
+               \`\`\`
+               [Terraform Cloud Plan](${{ steps.plan-run.outputs.run_link }})
+               `;
+            // 3. Delete previous comment so PR timeline makes sense
+            if (botComment) {
+              github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+              });
+            }
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rms-db-iac
 Contains the Database related Infrastructure as code (IaC) of the [RMS project](https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff).
 
-[badge do CI aqui]\
+[![Terraform Plan](https://github.com/Grupo-G03-4SOAT-FIAP/rms-db-iac/actions/workflows/terraform-plan.yml/badge.svg)](https://github.com/Grupo-G03-4SOAT-FIAP/rms-db-iac/actions/workflows/terraform-plan.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Grupo-G03-4SOAT-FIAP_rms-db-iac&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Grupo-G03-4SOAT-FIAP_rms-db-iac)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Grupo-G03-4SOAT-FIAP_rms-db-iac&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=Grupo-G03-4SOAT-FIAP_rms-db-iac)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=Grupo-G03-4SOAT-FIAP_rms-db-iac
+sonar.organization=grupo-g03-4soat-fiap
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=rms-db-iac
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Pessoal, bom dia (caso forem ler amanhã pela manhã)

Fiz a parte do CI com o SonarCloud e a parte do CD do Terraform do banco de dados com o Terraform Cloud.

<img width="733" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-db-iac/assets/5115895/59ba5f6d-d010-4d64-8905-22872dc08ad5">

<br>
<br>

Segui a risca as instruções do tutorial oficial do portal **HashiCorp Developer** em https://developer.hashicorp.com/terraform/tutorials/automation/github-actions e não inventei moda, fiz exatamente igual o yaml que eles usam como exemplo.

Como vocês podem ver no link acima, a HashiCorp pede para separar o CI do CD em 2 yamls diferentes.

O Sonar já estava habilitado, porém estava no modo "Automatic Analysis" que não exige a presença de um arquivo yaml pro Sonar funcionar.
<img width="404" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-db-iac/assets/5115895/44be9f58-8568-4ef1-8f53-264ac6a1f643">
Para não correr o risco dos professores depois falarem "ah mas tinha que ter feito o yaml na unha, não pode usar o modo de análise automática sem yaml" eu resolvi criar um sonarcloud.yml na pastinha `.github/workflows` tmb.

## IMPORTANTE

⚠️ Pro Terraform Cloud funcionar eu precisei criar uma organização no Terraform Cloud com o mesmo nome da nossa organização no GitHub "Grupo-G03-4SOAT-FIAP". Essa organização do Terraform Cloud está "ligada" à minha conta pessoal da AWS (conta paga) ou seja, quando uma PR for aberta aqui, o deploy vai ser feito automaticamente na minha conta da AWS (paga). Infelizmente a conta da FIAP tem limitações no IAM.
Sendo assim, pelo que tomem um pouco de cuidado ao fazer testes por aqui. Mas, caso aconteça de rodar aqui e subir alguma coisa na minha conta da AWS é só dar um ping lá no Discord que eu vou lá e excluo logo em seguida para não me cobrar.

Depois precisamos marcar um dia para eu explicar como funciona esse CD e o Terraform Cloud.