### PR TITLE
ci: Adequa TF ao padrão de nomenclatura da AWS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,12 +8,19 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.5.2"
 
-  name                 = "rms-prod-vpc"
-  cidr                 = "10.0.0.0/16"
-  azs                  = data.aws_availability_zones.available.names
-  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  name = "rms-prod-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs            = data.aws_availability_zones.available.names
+  public_subnets = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+
   enable_dns_hostnames = true
   enable_dns_support   = true
+
+  tags = {
+    Terraform   = "true"
+    Environment = "prod"
+  }
 }
 
 resource "aws_db_subnet_group" "rms" {
@@ -21,7 +28,9 @@ resource "aws_db_subnet_group" "rms" {
   subnet_ids = module.vpc.public_subnets
 
   tags = {
-    Name = "rms"
+    Name        = "rms"
+    Terraform   = "true"
+    Environment = "prod"
   }
 }
 
@@ -44,7 +53,9 @@ resource "aws_security_group" "rds" {
   }
 
   tags = {
-    Name = "rds"
+    Name        = "rds"
+    Terraform   = "true"
+    Environment = "prod"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_db_parameter_group" "rms" {
 
   parameter {
     name  = "rds.force_ssl"
-    value = "0"
+    value = "0" # Desativa o SSL obrigatório
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ module "vpc" {
   cidr = "10.0.0.0/16"
 
   azs            = data.aws_availability_zones.available.names
-  public_subnets = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  public_subnets = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
   enable_dns_hostnames = true
   enable_dns_support   = true

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.5.2"
 
-  name                 = "rms-db"
+  name                 = "rms-prod-vpc"
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
   public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
@@ -16,17 +16,17 @@ module "vpc" {
   enable_dns_support   = true
 }
 
-resource "aws_db_subnet_group" "rms-db" {
-  name       = "rms-db"
+resource "aws_db_subnet_group" "rms" {
+  name       = "rms-prod-subnetgroup"
   subnet_ids = module.vpc.public_subnets
 
   tags = {
-    Name = "rms-db"
+    Name = "rms"
   }
 }
 
 resource "aws_security_group" "rds" {
-  name   = "rms-db_rds"
+  name   = "rms-prod-securitygroup"
   vpc_id = module.vpc.vpc_id
 
   ingress {
@@ -44,12 +44,12 @@ resource "aws_security_group" "rds" {
   }
 
   tags = {
-    Name = "rms-db_rds"
+    Name = "rds"
   }
 }
 
-resource "aws_db_parameter_group" "rms-db" {
-  name   = "rms-db-pg16-parameter-group"
+resource "aws_db_parameter_group" "rms" {
+  name   = "rms-prod-paramgroup"
   family = "postgres16"
 
   parameter {
@@ -58,17 +58,17 @@ resource "aws_db_parameter_group" "rms-db" {
   }
 }
 
-resource "aws_db_instance" "rms-db" {
-  identifier             = "rms-db"
-  instance_class         = "db.t3.micro"
+resource "aws_db_instance" "rms" {
+  identifier             = "rms-prod-postgres-standalone"
+  instance_class         = "db.t3.micro" # A instance_class do Free Tier é db.t3.micro
   allocated_storage      = 5
   engine                 = "postgres"
   engine_version         = "16.1"
   username               = "postgres"
   password               = var.db_password
-  db_subnet_group_name   = aws_db_subnet_group.rms-db.name
+  db_subnet_group_name   = aws_db_subnet_group.rms.name
   vpc_security_group_ids = [aws_security_group.rds.id]
-  parameter_group_name   = aws_db_parameter_group.rms-db.name
+  parameter_group_name   = aws_db_parameter_group.rms.name
   publicly_accessible    = true
   skip_final_snapshot    = true
 }

--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,9 @@ module "vpc" {
   name = "rms-prod-vpc"
   cidr = "10.0.0.0/16"
 
-  azs            = data.aws_availability_zones.available.names
-  public_subnets = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  azs             = data.aws_availability_zones.available.names
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 
   enable_dns_hostnames = true
   enable_dns_support   = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,18 +1,18 @@
 output "rds_hostname" {
   description = "RDS instance hostname"
-  value       = aws_db_instance.rms-db.address
+  value       = aws_db_instance.rms.address
   sensitive   = true
 }
 
 output "rds_port" {
   description = "RDS instance port"
-  value       = aws_db_instance.rms-db.port
+  value       = aws_db_instance.rms.port
   sensitive   = true
 }
 
 output "rds_username" {
   description = "RDS instance root username"
-  value       = aws_db_instance.rms-db.username
+  value       = aws_db_instance.rms.username
   sensitive   = true
 }
 


### PR DESCRIPTION
Só refatorando a nomenclatura dos serviços AWS de acordo com o padrão de nomenclatura recomendado em https://peritossolutions.com/aws/aws-workload-naming-convention/